### PR TITLE
Alertmanager 0.1 and restricting to tracked projects

### DIFF
--- a/plugins/prometheus.py
+++ b/plugins/prometheus.py
@@ -15,7 +15,13 @@ queue = PriorityQueue()
 
 
 class PrometheusPlugin(Plugin):
-    """Plugin for interacting with Prometheus.
+    """ Plugin for receiving Prometheus alerts.
+    prometheus show projects : Display which projects this bot recognises.
+    prometheus show track|tracking : Display which projects this bot is tracking.
+    prometheus track project1 project2 ... : Track Prometheus notifications for the named projects.
+    prometheus stop track|tracking : Stop tracking Prometheus notifications.
+    prometheus add projectName : Start tracking projectName.
+    prometheus remove projectName : Stop tracking projectName.
     """
     name = "prometheus"
 

--- a/prometheus.json
+++ b/prometheus.json
@@ -1,3 +1,4 @@
 {
-    "message_template": "[ALERT] {{labels.alertname}} : {{summary}}\n{{payload.generatorURL}}\n{{description}}\nValue: {{payload.value}}\n{{payload.alertingRule}}\nActive since: {{payload.activeSince}}"
+    "v1_message_template": "[ALERT] {{labels.alertname}} : {{summary}}\n{{payload.generatorURL}}\n{{description}}\nValue: {{payload.value}}\n{{payload.alertingRule}}\nActive since: {{payload.activeSince}}",
+    "v2_message_template": "[ALERT] {{labels.alertname}} : {{annotations.summary}}\n{{labels.job}} on {{labels.instance}}\n{{status}}\n{{annotations.description}}\n{{generatorURL}}\nStarted: {{startsAt}} ; Ended: {{endsAt}}"
 }

--- a/prometheus.json
+++ b/prometheus.json
@@ -1,5 +1,5 @@
 {
-    "known_projects": [],
+    "known_projects": ["prometheus"],
     "v1_message_template": "[ALERT] {{labels.alertname}} : {{summary}}\n{{payload.generatorURL}}\n{{description}}\nValue: {{payload.value}}\n{{payload.alertingRule}}\nActive since: {{payload.activeSince}}",
     "v2_message_template": "[ALERT] {{labels.alertname}} : {{annotations.summary}}\n{{labels.job}} on {{labels.instance}}\n{{status}}\n{{annotations.description}}\n{{generatorURL}}\nStarted: {{startsAt}} ; Ended: {{endsAt}}"
 }

--- a/prometheus.json
+++ b/prometheus.json
@@ -1,4 +1,5 @@
 {
+    "known_projects": [],
     "v1_message_template": "[ALERT] {{labels.alertname}} : {{summary}}\n{{payload.generatorURL}}\n{{description}}\nValue: {{payload.value}}\n{{payload.alertingRule}}\nActive since: {{payload.activeSince}}",
     "v2_message_template": "[ALERT] {{labels.alertname}} : {{annotations.summary}}\n{{labels.job}} on {{labels.instance}}\n{{status}}\n{{annotations.description}}\n{{generatorURL}}\nStarted: {{startsAt}} ; Ended: {{endsAt}}"
 }


### PR DESCRIPTION
This is all a bit of a hack.

Basically to 'enable' alerts from prometheus to be sent to a room, I just `!prometheus track prometheus` in that room. prometheus is set as a known_project in the config file so that then when issuing that command, the room state is changed for tracking.

Then, when the NEB instance is hit on the prometheus endpoint, it checks the room's state to see if the prometheus plugin state member for the room contains anything (it doesn't do actual project matching as I'm not plucking anything from the prometheus alertmanager payload to identify it yet) and if so then it will send the message to that room, else not.
