### PR TITLE
Upgrade base of NEB to 0.0.5 of matrix-python-sdk

### DIFF
--- a/neb.py
+++ b/neb.py
@@ -127,7 +127,6 @@ if __name__ == '__main__':
             hsurl = raw_input("Home server URL (e.g. http://localhost:8008): ").strip()
             if hsurl.endswith("/"):
                 hsurl = hsurl[:-1]
-            hsurl = hsurl + "/_matrix/client/api/v1"  # v1 compatibility
             username = raw_input("Full user ID (e.g. @user:domain): ").strip()
             token = raw_input("Access token: ").strip()
             config = generate_config(hsurl, username, token, args.config)

--- a/neb/matrix.py
+++ b/neb/matrix.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import json
+import logging as log
 
 
 class MatrixConfig(object):
@@ -26,8 +27,15 @@ class MatrixConfig(object):
     @classmethod
     def from_file(cls, f):
         j = json.load(f)
+
+        # convert old 0.0.1 matrix-python-sdk urls to 0.0.3+
+        hs_url = j[MatrixConfig.URL]
+        if hs_url.endswith("/_matrix/client/api/v1"):
+            hs_url = hs_url[:-22]
+            log.info("Detected legacy URL, using '%s' instead. Consider changing this in your configuration." % hs_url)
+
         return MatrixConfig(
-            hs_url=j[MatrixConfig.URL],
+            hs_url=hs_url,
             user_id=j[MatrixConfig.USR],
             access_token=j[MatrixConfig.TOK],
             admins=j[MatrixConfig.ADM]

--- a/neb/plugins.py
+++ b/neb/plugins.py
@@ -20,7 +20,7 @@ def admin_only(fn):
     def wrapped(*args, **kwargs):
         config = args[0].config
         event = args[1]
-        if event["user_id"] not in config.admins:
+        if event["sender"] not in config.admins:
             return "Sorry, only %s can do that." % json.dumps(config.admins)
         result = fn(*args, **kwargs)
         return result

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
         "python-dateutil"
     ],
     dependency_links=[
-        "https://github.com/matrix-org/matrix-python-sdk/tarball/v0.0.1#egg=matrix_client-0.0.1"
+        "https://github.com/matrix-org/matrix-python-sdk/tarball/v0.0.5#egg=matrix_client-0.0.5"
     ]
 )


### PR DESCRIPTION
Addresses #15.

Changes:
* Automatically remove `/_matrix/client/api/v1` from URL for compatibility with `matrix-python-sdk`
* Use newer `/sync` endpoints instead of initalSync and eventStream.
  * By proxy, update references to keys of Events.

I haven't tested the packaged plugins extensively, but they don't complain on startup and appear to be working fine. The only plugin I can't test is Jira due to lack of environment.