### PR TITLE
Optional configuration flag for case insensitive commands

### DIFF
--- a/neb/engine.py
+++ b/neb/engine.py
@@ -77,6 +77,9 @@ class Engine(object):
             try:
                 segments = body.split()
                 cmd = segments[0][1:]
+                if self.config.case_insensitive:
+                    cmd = cmd.lower()
+
                 if cmd == "help":
                     if len(segments) == 2 and segments[1] in self.plugins:
                         # return help on a plugin

--- a/neb/matrix.py
+++ b/neb/matrix.py
@@ -7,12 +7,14 @@ class MatrixConfig(object):
     USR = "user"
     TOK = "token"
     ADM = "admins"
+    CIS = "case_insensitive"
 
-    def __init__(self, hs_url, user_id, access_token, admins):
+    def __init__(self, hs_url, user_id, access_token, admins, case_insensitive):
         self.user_id = user_id
         self.token = access_token
         self.base_url = hs_url
         self.admins = admins
+        self.case_insensitive = case_insensitive
 
     @classmethod
     def to_file(cls, config, f):
@@ -20,7 +22,8 @@ class MatrixConfig(object):
             MatrixConfig.URL: config.base_url,
             MatrixConfig.TOK: config.token,
             MatrixConfig.USR: config.user_id,
-            MatrixConfig.ADM: config.admins
+            MatrixConfig.ADM: config.admins,
+            MatrixConfig.CIS: config.case_insensitive
         }, indent=4))
 
     @classmethod
@@ -30,5 +33,6 @@ class MatrixConfig(object):
             hs_url=j[MatrixConfig.URL],
             user_id=j[MatrixConfig.USR],
             access_token=j[MatrixConfig.TOK],
-            admins=j[MatrixConfig.ADM]
+            admins=j[MatrixConfig.ADM],
+            case_insensitive=j[MatrixConfig.CIS] if MatrixConfig.CIS in j else False
         )

--- a/neb/plugins.py
+++ b/neb/plugins.py
@@ -107,6 +107,8 @@ class Plugin(PluginInterface):
         # more general until no args remain (in which case there isn't a match)
         for index, arg in enumerate(args_array):
             possible_method = "cmd_" + "_".join(args_array[:(len(args_array) - index)])
+            if self.config.case_insensitive:
+                possible_method = possible_method.lower()
             if hasattr(self, possible_method):
                 method = getattr(self, possible_method)
                 remaining_args = [event] + args_array[len(args_array) - index:]


### PR DESCRIPTION
Allows for users to use something like `!GitHub Track <whatever>`

This spawned from a user request on our homeserver where their mobile devices were auto-completing words into different cases (GitHub, Jira, etc) - causing commands to fail.

The default behaviour of strict case is maintained if the flag is missing from the config or first time setup of the bot.