### PR TITLE
Load all plugins found in the plugins folder automatically.

### DIFF
--- a/neb.py
+++ b/neb.py
@@ -4,14 +4,8 @@ import argparse
 from matrix_client.api import MatrixHttpApi
 from neb.engine import Engine
 from neb.matrix import MatrixConfig
-from plugins.b64 import Base64Plugin
-from plugins.guess_number import GuessNumberPlugin
-from plugins.jenkins import JenkinsPlugin
-from plugins.jira import JiraPlugin
-from plugins.url import UrlPlugin
-from plugins.time_utils import TimePlugin
-from plugins.github import GithubPlugin
-from plugins.prometheus import PrometheusPlugin
+from neb.plugins import PluginInterface, Plugin
+from plugins import *  # Appears unused, but is used to dynamically load the plugins
 
 import logging
 import logging.handlers
@@ -64,22 +58,20 @@ def configure_logging(logfile):
         handler.setFormatter(formatter)
         logging.getLogger('').addHandler(handler)
 
+def get_subclasses(cls):
+    subclasses = []
+    for subclass in cls.__subclasses__():
+        subclasses.append(subclass)
+        subclasses.extend(get_subclasses(subclass))
+    return subclasses
 
 def main(config):
     # setup api/endpoint
     matrix = MatrixHttpApi(config.base_url, config.token)
 
     log.debug("Setting up plugins...")
-    plugins = [
-        TimePlugin,
-        Base64Plugin,
-        GuessNumberPlugin,
-        JiraPlugin,
-        UrlPlugin,
-        GithubPlugin,
-        JenkinsPlugin,
-        PrometheusPlugin,
-    ]
+    plugins = get_subclasses(PluginInterface)
+    plugins = [p for p in plugins if p != Plugin]  # filter out the Plugin abstract class
 
     # setup engine
     engine = Engine(matrix, config)

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,1 +1,10 @@
 # -*- coding: utf-8 -*-
+
+from os.path import dirname, basename, isfile
+
+import glob
+
+
+# load all plugins in this directory, except this file (__init__.py)
+modules = glob.glob(dirname(__file__) + "/*.py")
+__all__ = [basename(f)[:-3] for f in modules if isfile(f) and f.find("__init__") == -1]


### PR DESCRIPTION
This is more of a convenience thing than anything else. It could be useful for administrators with limited Python experience to eliminate the need to edit the actual code to get their plugins working. I'm using this to make it easier to add plugins to the bot instance we're running.